### PR TITLE
Upgrade step for IPAddress Life field

### DIFF
--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2251,3 +2251,19 @@ func countOldIndexes(c *gc.C, coll *mgo.Collection) (foundCount, oldCount int) {
 	}
 	return
 }
+
+func (s *upgradesSuite) TestIPAddressesLife(c *gc.C) {
+	addresses, closer := s.state.getRawCollection(ipaddressesC)
+	defer closer()
+
+	uuid := s.state.EnvironUUID()
+
+	err := addresses.Insert(
+		bson.D{
+			{"name", "ok"},
+			{"env-uuid", uuid},
+			{"counter", 1},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2260,10 +2260,37 @@ func (s *upgradesSuite) TestIPAddressesLife(c *gc.C) {
 
 	err := addresses.Insert(
 		bson.D{
-			{"name", "ok"},
+			{"_id", uuid + ":0.1.2.3"},
 			{"env-uuid", uuid},
-			{"counter", 1},
+			{"subnetid", "foo"},
+			{"machineid", "bar"},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.3"},
+			{"state", ""},
+		},
+		// this one should be untouched
+		bson.D{
+			{"_id", uuid + ":0.1.2.4"},
+			{"env-uuid", uuid},
+			{"life", Dead},
+			{"subnetid", "foo"},
+			{"machineid", "bar"},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.4"},
+			{"state", ""},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddLifeFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ipAddr, err := s.state.IPAddress("0.1.2.4")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.Life(), gc.Equals, Dead)
+
+	doc := ipaddressDoc{}
+	err = addresses.FindId(uuid + ":0.1.2.3").One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(doc.Life, gc.Equals, Alive)
 }

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -57,6 +57,12 @@ func stateStepsFor123() []Step {
 			run: func(context Context) error {
 				return state.AddNameFieldLowerCaseIdOfUsers(context.State())
 			},
+		}, &upgradeStep{
+			description: "add life field to IP addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddLifeFieldOfIPAddresses(context.State())
+			},
 		},
 	)
 	return steps

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -29,6 +29,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"move blocks from environment to state",
 		"insert userenvnameC doc for each environment",
 		"add name field to users and lowercase _id field",
+		"add life field to IP addresses",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)
 }


### PR DESCRIPTION
Adds an upgrade step to add the Life field (defaulting to Alive) for all IPAddresses.